### PR TITLE
Remove Microsoft.VisualStudio.Debugger.Interop

### DIFF
--- a/src/14.0/Microsoft.VisualStudio.SDK.14.0.csproj
+++ b/src/14.0/Microsoft.VisualStudio.SDK.14.0.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.VisualStudio.CommandBars" Version="8.0.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="14.0.25424" PrivateAssets="none" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="$(VsVersion)" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop" Version="8.0.50729" PrivateAssets="none" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.10.0" Version="10.0.30320" PrivateAssets="none" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.12.0" Version="12.0.21006" PrivateAssets="none" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Interop.14.0" Version="$(VsVersion)" PrivateAssets="none" />


### PR DESCRIPTION
Removed the `Microsoft.VisualStudio.Debugger.Interop` reference (which is for Dev 8.0) because `Microsoft.VisualStudio.Debugger.Interop.10.0` depends upon `Microsoft.VisualStudio.Debugger.InteropA` (Dev 9.0), which appears to export the same interfaces as 8.0.

See the Dependencies listed for the [Microsoft.VisualStudio.Debugger.Interop.10.0 nuget package](https://www.nuget.org/packages/Microsoft.VisualStudio.Debugger.Interop.10.0/10.0.30320)

I'm not sure if `Interop.10.0` depending on `InteropA` is deliberate or a mistake. But it means that if a project (likely transitively) brings in both  `Microsoft.VisualStudio.Debugger.Interop` and  `Microsoft.VisualStudio.Debugger.InteropA`, there will be clashes if it tries to use types like `IDebugThread2`, since it's available in both.